### PR TITLE
9 Default support for types with no-args-constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,14 @@ Apart from that if you want to controll range / legnth / size of the values bein
   - Functional types (high-order functions, lambdas)
   - `@Dowel` classes (`@Dowel` classes can be nested. A `@Dowel` annotated class can have properties of the type of classes which are again annotated with `@Dowel`)
   - Types for which a user-defined `PreviewParameterProvider` exist (via the `@ConsiderForDowel` annotation)
+  - Types which have a no-args constructor, or all of the properties of at-least a single constructor have default values
   - `Sealed` types
   - Kotlin Objects
   - `Enum`
   - `List`
   - `Map`
   - `Pair`
+  - Nullable types
   - Properties with **unsupported** types which are nullable are allowed, and the generated value would always be null
   - Properties with default values can have *any type*, as they are not considered while generating code
   - Types in the above mentioned list having generic type parameters (like `List` and `Map`) can only have `@Dowel` supported types as their type parameters. Like `List<String>`, `Map<String, @Dowel class>`

--- a/dowel-annotation/src/main/java/com/jayasuryat/dowel/annotation/ConsiderForDowel.kt
+++ b/dowel-annotation/src/main/java/com/jayasuryat/dowel/annotation/ConsiderForDowel.kt
@@ -34,7 +34,9 @@ package com.jayasuryat.dowel.annotation
  * [androidx.compose.ui.tooling.preview.PreviewParameterProvider] - instances will be retrieved from
  * an instance of that provider for that type, instead of building instances by *hand*.
  *
- * **Note** : Only a single class can be annotated with @[ConsiderForDowel] per type.
+ * **Note** : Only a single class can be annotated with @[ConsiderForDowel] per type. Classes
+ * annotated with @[ConsiderForDowel] must have at-least a single non-private no-args constructor,
+ * alternatively all of the properties of that constructor must default values.
  *
  * @see [Dowel]
  */

--- a/dowel-annotation/src/main/java/com/jayasuryat/dowel/annotation/Dowel.kt
+++ b/dowel-annotation/src/main/java/com/jayasuryat/dowel/annotation/Dowel.kt
@@ -34,9 +34,11 @@ import com.jayasuryat.dowel.annotation.internal.DowelInternal
  * * [kotlinx.coroutines.flow.Flow]
  * * Functional types (high-order functions)
  * * @[Dowel] classes (@[Dowel] classes can be nested. A @[Dowel] annotated class can have
- *   properties of type of classes which are again annotated with @[Dowel])
+ * properties of type of classes which are again annotated with @[Dowel])
  * * Types for which a user-defined PreviewParameterProvider exist (via the @[ConsiderForDowel]
  * annotation)
+ * * Types which have a no-args constructor, or all of the properties of at-least a single constructor
+ * have default values
  * * Sealed types
  * * Kotlin Objects
  * * [Enum]
@@ -55,8 +57,8 @@ import com.jayasuryat.dowel.annotation.internal.DowelInternal
  * have @[Dowel] supported types as their type parameters.
  * Like List&lt;String&gt;, Map&lt;String, @[Dowel] class&gt;.
  *
- * As far as a type is in this supported list, there are no practical limitations on how many times they may be nested.
- * Like List&lt;Map&lt;String, List&lt;@[Dowel] class&gt;&gt;&gt;
+ * As far as a type is in this supported list, there are no practical limitations on how many times
+ * they may be nested. Like List&lt;Map&lt;String, List&lt;@[Dowel] class&gt;&gt;&gt;
  *
  * **Note** : More meta information about a property can be given to Dowel using [androidx.annotation]
  * annotations. Currently, following are the supported annotations:

--- a/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/generator/DowelGenerator.kt
+++ b/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/generator/DowelGenerator.kt
@@ -251,6 +251,7 @@ internal class DowelGenerator(
                 is ClassRepresentation.ParameterSpec.FunctionSpec,
                 is ClassRepresentation.ParameterSpec.EnumSpec,
                 is ClassRepresentation.ParameterSpec.ObjectSpec,
+                is ClassRepresentation.ParameterSpec.NoArgsConstructorSpec,
                 is ClassRepresentation.ParameterSpec.UnsupportedNullableSpec,
                 -> emptyList()
 

--- a/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/generator/ObjectConstructor.kt
+++ b/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/generator/ObjectConstructor.kt
@@ -95,7 +95,9 @@ internal class ObjectConstructor {
             is ObjectSpec -> spec.getObjectAssigner()
             is DowelSpec -> spec.getDowelAssigner()
 
-            is PreDefinedProviderSpec -> spec.getPreDefinedProviderSpecAssigner()
+            is PreDefinedProviderSpec -> spec.getPreDefinedProviderAssigner()
+
+            is NoArgsConstructorSpec -> spec.getNoArgsConstructorAssigner()
 
             is UnsupportedNullableSpec -> spec.getUnsupportedNullableAssigner()
         }
@@ -317,7 +319,7 @@ internal class ObjectConstructor {
         }
     }
 
-    private fun PreDefinedProviderSpec.getPreDefinedProviderSpecAssigner(): CodeBlock {
+    private fun PreDefinedProviderSpec.getPreDefinedProviderAssigner(): CodeBlock {
 
         val spec = this
 
@@ -325,6 +327,13 @@ internal class ObjectConstructor {
         return buildCodeBlock {
             val propName = spec.propertyName
             add("$propName.random()")
+        }
+    }
+
+    private fun NoArgsConstructorSpec.getNoArgsConstructorAssigner(): CodeBlock {
+        val className = this.classDeclarations.toClassName()
+        return buildCodeBlock {
+            add("%T()", className)
         }
     }
 

--- a/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/model/ClassRepresentation.kt
+++ b/dowel-processor/src/main/java/com/jayasuryat/dowel/processor/model/ClassRepresentation.kt
@@ -149,6 +149,15 @@ internal data class ClassRepresentation(
         ) : ParameterSpec, BackedSpec
 
         /**
+         * Types whose instances can be created by invoking a no-args constructor. It could be that
+         * the class has a no-args constructor, or all of the arguments of a at-least a single
+         * constructor have default values.
+         */
+        data class NoArgsConstructorSpec(
+            val classDeclarations: KSClassDeclaration,
+        ) : ParameterSpec
+
+        /**
          * Types which are not directly supported by Dowel for code generation, but are nullable
          */
         object UnsupportedNullableSpec : ParameterSpec

--- a/dowel-processor/src/test/java/com/jayasuryat/dowel/processor/DowelProcessingTest.kt
+++ b/dowel-processor/src/test/java/com/jayasuryat/dowel/processor/DowelProcessingTest.kt
@@ -131,6 +131,8 @@ internal class DowelProcessingTest {
             internal data class Person(
                 val name: String,
                 val age: String,
+                val location : Location,
+                val geoData : Location.GeoData,
             ){
             
                 @Dowel
@@ -147,6 +149,40 @@ internal class DowelProcessingTest {
             }
         """.trimIndent()
 
+        val kotlinSource: SourceFile = SourceFile.kotlin(name = "Person.kt", contents = source)
+        val result: KotlinCompilation.Result = compile(kotlinSource, PreviewParameterProviderStub)
+
+        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        Assert.assertEquals("", result.messages)
+    }
+
+    @Test
+    fun `should compile success for dowel with non-dowel types with no-args constructor`() {
+
+
+        val source = """
+            package dowel
+            
+            import com.jayasuryat.dowel.annotation.Dowel
+            
+            @Dowel
+            internal data class Person(
+                val name: String,
+                val age: String,
+                val location : Location,
+                val geoData : Location.GeoData,
+            ){
+            
+                class Location {
+                    val lat : Long = 0
+                    val lon : Long = 0
+                
+                    data class GeoData(
+                        val data : Long = -1,
+                    )                
+                }
+            }
+        """.trimIndent()
         val kotlinSource: SourceFile = SourceFile.kotlin(name = "Person.kt", contents = source)
         val result: KotlinCompilation.Result = compile(kotlinSource, PreviewParameterProviderStub)
 

--- a/dowel-processor/src/test/java/com/jayasuryat/dowel/processor/DowelWholeEnchiladaProcessingTest.kt
+++ b/dowel-processor/src/test/java/com/jayasuryat/dowel/processor/DowelWholeEnchiladaProcessingTest.kt
@@ -206,14 +206,25 @@ internal class DowelWholeEnchiladaProcessingTest {
                 val vehicle: Vehicle,
                 val liveLocation: Flow<Location?>,
                 val latLon: Pair<Long, Long>,
-                val meta: SomeStaticInfo,
+                val info: SomeStaticInfo,
                 @Size(value = 2) val locations: List<Location>,
                 val isExpanded: State<Boolean>,
                 @Size(value = 1) val preferences: Map<Long, Location>,
                 val title: Char,
                 @Size(value = 1) val interests: List<Float>,
+                val meta : MetaInfo,
+                val subjects : Subjects,
                 val onClick: suspend (a: Person, b: Int) -> Unit,
-            )
+            ){
+                
+                class MetaInfo {
+                    var info : Long = -1
+                }
+            
+                data class Subjects(
+                    val subjects : List<String> = emptyList(),
+                )
+            }
         """.trimIndent()
 
         val kotlinSource: SourceFile = SourceFile.kotlin(name = "Person.kt", contents = source)


### PR DESCRIPTION
This PR brings in default support for types having no-args-constructors. Read more at #9 